### PR TITLE
Render static markup in a div (not autogenerated)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,27 @@
 </aside>
 </div>
 
+<h2>Supplies Source Panel in Markup</h2>
+<div data-xrayhtml>
+	<aside>
+	<blockquote>
+	<p>It is the unofficial force—the Baker Street irregulars.</p>
+	</blockquote>
+	<address>Sherlock Holmes</address>
+	<cite>Sign of Four</cite>
+	</aside>
+
+<div class="source-panel">
+<aside>
+<blockquote>
+<p>It is the unofficial force—the Baker Street irregulars (yes it can be different).</p>
+</blockquote>
+<address>Sherlock Holmes</address>
+<cite>Sign of Four</cite>
+</aside>
+</div>
+</div>
+
 <h2>Add a subtitle</h2>
 <p>Use a heading element with an <code>xraytitle</code> class to add your own subtitle to the example text.</p>
 <p>Also works with a <code>data-title</code> attribute but that approach is deprecated.</p>

--- a/src/X-rayHTML.js
+++ b/src/X-rayHTML.js
@@ -138,15 +138,9 @@ window.jQuery = window.jQuery || window.shoestring;
 				}
 				return o.text.titlePrefix;
 			};
+
 			var title = el.getElementsByClassName( o.classes.title );
 			var deprecatedTitle;
-			var preel = document.createElement( "pre" );
-			var codeel = document.createElement( "code" );
-			var wrap = document.createElement( "div" );
-			var sourcepanel = document.createElement( "div" );
-			var code;
-			var leadingWhiteSpace;
-			var source;
 
 			if( title.length ) {
 				title = title[ 0 ];
@@ -159,8 +153,24 @@ window.jQuery = window.jQuery || window.shoestring;
 				title.innerHTML = getPrefixText() + ( deprecatedTitle ? ": " + deprecatedTitle : "" );
 			}
 
+			var suppliedsourcepanel = $( el ).find("." + o.classes.sourcepanel );
+			var sourcepanel = document.createElement( "div" );
+			var preel = document.createElement( "pre" );
+			var codeel = document.createElement( "code" );
+			var wrap = document.createElement( "div" );
+			var code;
+			var leadingWhiteSpace;
+			var source;
+
+			if( suppliedsourcepanel.length ) {
+				code = suppliedsourcepanel[0].innerHTML;
+				suppliedsourcepanel.remove();
+			} else {
+				code = el.innerHTML;
+			}
+
 			// remove empty value attributes
-			code = el.innerHTML.replace( /\=\"\"/g, '' );
+			code = code.replace( /\=\"\"/g, '' );
 			leadingWhiteSpace = code.match( /(^[\s]+)/ );
 
 			if( leadingWhiteSpace ) {
@@ -180,6 +190,7 @@ window.jQuery = window.jQuery || window.shoestring;
 			sourcepanel.appendChild( preel );
 
 			this.appendChild( sourcepanel );
+
 			this.insertBefore( title, this.firstChild );
 		}
 	};


### PR DESCRIPTION
Usage:

```
<div data-xrayhtml>
	<aside>
		<blockquote>
			<p>It is the unofficial force—the Baker Street irregulars.</p>
		</blockquote>
		<address>Sherlock Holmes</address>
		<cite>Sign of Four</cite>
	</aside>

<div class="source-panel">
<aside>
	<blockquote>
		<p>It is the unofficial force—the Baker Street irregulars (yes it can be different).</p>
	</blockquote>
	<address>Sherlock Holmes</address>
	<cite>Sign of Four</cite>
</aside>
</div>
</div>
```

Option to put the raw unescaped markup in your own source-panel div, instead of it being generated.